### PR TITLE
get:/api/members/me

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 ## Intro.
 >- **What's Hot 프로젝트 REST API**
 >- **맛집, 여행지, 숙박 리뷰 앱**
->- **[개발 로그](https://github.com/cojar/whats_hot_backend/blob/main/dev-log/DEV-LOG.md)**
+>- **[개발 로그](https://github.com/cojar/whats_hot_backend/blob/dev/dev-log/DEV-LOG.md)**

--- a/dev-log/DEV-LOG.md
+++ b/dev-log/DEV-LOG.md
@@ -1,5 +1,9 @@
 # What's Hot Dev-Log
 
+## 23-12-15
+### feature/get-api-members-me
+- [x] S-01-04 TC 작성
+
 ## 23-12-13
 - [x] 컨트롤러 묘듈 패키징
 - [x] 컨트롤러 테스트 파일 생성

--- a/dev-log/DEV-LOG.md
+++ b/dev-log/DEV-LOG.md
@@ -3,6 +3,7 @@
 ## 23-12-15
 ### feature/get-api-members-me
 - [x] S-01-04 TC 작성
+- [x] README.md 개발로그 링크 dev tree로 변경
 
 ## 23-12-13
 - [x] 컨트롤러 묘듈 패키징

--- a/dev-log/DEV-LOG.md
+++ b/dev-log/DEV-LOG.md
@@ -4,6 +4,7 @@
 ### feature/get-api-members-me
 - [x] S-01-04 TC 작성
 - [x] README.md 개발로그 링크 dev tree로 변경
+- [x] 테스트 코드 MemberService 의존성 주입 부분 BaseControllerTest로 이전
 
 ## 23-12-13
 - [x] 컨트롤러 묘듈 패키징

--- a/src/main/java/com/cojar/whats_hot_backend/domain/member_module/member/request/MemberRequest.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/member_module/member/request/MemberRequest.java
@@ -3,6 +3,7 @@ package com.cojar.whats_hot_backend.domain.member_module.member.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
+import org.springframework.stereotype.Component;
 
 @Getter
 public class MemberRequest {
@@ -24,6 +25,7 @@ public class MemberRequest {
     }
 
     @Getter
+    @Component
     public static class Login {
 
         @Schema(example = "user1")
@@ -33,6 +35,13 @@ public class MemberRequest {
         @Schema(example = "1234")
         @NotBlank
         private String password;
+
+        public Login of(String username, String password) {
+            this.username = username;
+            this.password = password;
+
+            return this;
+        }
     }
 
     @Getter

--- a/src/test/java/com/cojar/whats_hot_backend/domain/member_module/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cojar/whats_hot_backend/domain/member_module/member/controller/MemberControllerTest.java
@@ -1,9 +1,58 @@
 package com.cojar.whats_hot_backend.domain.member_module.member.controller;
 
+import com.cojar.whats_hot_backend.domain.member_module.member.service.MemberService;
 import com.cojar.whats_hot_backend.global.controller.BaseControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class MemberControllerTest extends BaseControllerTest {
+
+    @Autowired
+    MemberService memberService;
+
+    @Test
+    @DisplayName("get:/api/members/me - ok")
+    public void me_ok() throws Exception {
+
+        // given
+        String username = "user1";
+        String password = "1234";
+        String accessToken = "Bearer " + this.memberService.getAccessToken(loginReq.of(username, password));
+
+        // when
+        ResultActions resultActions = this.mockMvc
+                .perform(get("/api/members/me")
+                        .header("Authorization", accessToken)
+                        .contentType(MediaType.ALL)
+                        .accept(MediaTypes.HAL_JSON)
+                )
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("status").value("OK"))
+                .andExpect(jsonPath("success").value("true"))
+                .andExpect(jsonPath("code").value("S-01-04"))
+                .andExpect(jsonPath("message").exists())
+                .andExpect(jsonPath("data.id").exists())
+                .andExpect(jsonPath("data.createDate").exists())
+                .andExpect(jsonPath("data.modifyDate").exists())
+                .andExpect(jsonPath("data.username").value("user1"))
+                .andExpect(jsonPath("data.email").exists())
+                .andExpect(jsonPath("data.authorities").exists())
+                .andExpect(jsonPath("_links.self").exists())
+                .andExpect(jsonPath("_links.profile").exists())
+        ;
+    }
 
 }

--- a/src/test/java/com/cojar/whats_hot_backend/domain/member_module/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cojar/whats_hot_backend/domain/member_module/member/controller/MemberControllerTest.java
@@ -1,10 +1,8 @@
 package com.cojar.whats_hot_backend.domain.member_module.member.controller;
 
-import com.cojar.whats_hot_backend.domain.member_module.member.service.MemberService;
 import com.cojar.whats_hot_backend.global.controller.BaseControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -15,9 +13,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class MemberControllerTest extends BaseControllerTest {
-
-    @Autowired
-    MemberService memberService;
 
     @Test
     @DisplayName("get:/api/members/me - ok, S-01-04")

--- a/src/test/java/com/cojar/whats_hot_backend/domain/member_module/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/cojar/whats_hot_backend/domain/member_module/member/controller/MemberControllerTest.java
@@ -20,8 +20,8 @@ class MemberControllerTest extends BaseControllerTest {
     MemberService memberService;
 
     @Test
-    @DisplayName("get:/api/members/me - ok")
-    public void me_ok() throws Exception {
+    @DisplayName("get:/api/members/me - ok, S-01-04")
+    public void me_OK() throws Exception {
 
         // given
         String username = "user1";
@@ -54,5 +54,4 @@ class MemberControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("_links.profile").exists())
         ;
     }
-
 }

--- a/src/test/java/com/cojar/whats_hot_backend/global/controller/BaseControllerTest.java
+++ b/src/test/java/com/cojar/whats_hot_backend/global/controller/BaseControllerTest.java
@@ -1,6 +1,7 @@
 package com.cojar.whats_hot_backend.global.controller;
 
 import com.cojar.whats_hot_backend.domain.member_module.member.request.MemberRequest;
+import com.cojar.whats_hot_backend.domain.member_module.member.service.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,9 @@ public class BaseControllerTest {
 
     @Autowired
     protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected MemberService memberService;
 
     @Autowired
     protected MemberRequest.Login loginReq;

--- a/src/test/java/com/cojar/whats_hot_backend/global/controller/BaseControllerTest.java
+++ b/src/test/java/com/cojar/whats_hot_backend/global/controller/BaseControllerTest.java
@@ -1,8 +1,8 @@
 package com.cojar.whats_hot_backend.global.controller;
 
+import com.cojar.whats_hot_backend.domain.member_module.member.request.MemberRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Disabled;
-import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -24,5 +24,5 @@ public class BaseControllerTest {
     protected ObjectMapper objectMapper;
 
     @Autowired
-    protected ModelMapper modelMapper;
+    protected MemberRequest.Login loginReq;
 }


### PR DESCRIPTION
## 미리보기(사진 or GIF)
<img src="https://i.imgur.com/OCYY1ES.png">

## 작업 브랜치
- feature/get-api-members-me

## 작업 진행 및 변경 사항
- 요청 헤더에 bearer token 담아서 보내면 해당하는 회원 정보를 반환하도록 함
- 해당 엔드포인트에 대한 TC 작업
S-01-04
- 테스트 코드에서 @WithUserDetails 사용하지 않고 직접 토큰 발급받도록 수정
```
// given
String username = "user1";
String password = "1234";
String accessToken = "Bearer " + this.memberService.getAccessToken(loginReq.of(username, password));
```

## 이후 할 작업
- memberModule 잔여 엔드포인트 작업 진행

## P.S.
##### 확인 후 리뷰 부탁합니다.
