### PR TITLE
post:/api/spots

### DIFF
--- a/dev-log/DEV-LOG.md
+++ b/dev-log/DEV-LOG.md
@@ -12,6 +12,7 @@
 ### feature/post-api-spots
 - [x] 생성 로직 수정
 - [x] 자식 엔티티 저장 후 refresh 되도록 수정
+- [x] 생성 TC 중 Bad Request 부분에서 엔티티 미생성 확인 추가
 
 ## 23-12-26
 ### feature/post-api-reviews

--- a/dev-log/DEV-LOG.md
+++ b/dev-log/DEV-LOG.md
@@ -11,6 +11,7 @@
 
 ### feature/post-api-spots
 - [x] 생성 로직 수정
+- [x] 자식 엔티티 저장 후 refresh 되도록 수정
 
 ## 23-12-26
 ### feature/post-api-reviews

--- a/dev-log/DEV-LOG.md
+++ b/dev-log/DEV-LOG.md
@@ -9,6 +9,9 @@
 - [x] deleteValidate 오류 메시지 출력 내용 수정
 - [x] likeValidate 오류 메시지 출력 내용 수정
 
+### feature/post-api-spots
+- [x] 생성 로직 수정
+
 ## 23-12-26
 ### feature/post-api-reviews
 - [x] conflict issue 해결

--- a/src/main/java/com/cojar/whats_hot_backend/domain/base_module/file/service/FileService.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/base_module/file/service/FileService.java
@@ -161,10 +161,16 @@ public class FileService {
         return null;
     }
 
+    @Transactional
     public List<_File> createAll(List<MultipartFile> images, FileDomain fileDomain) {
-        return images.stream()
+
+        List<_File> files = images.stream()
                 .map(image -> this.create(image, fileDomain))
                 .collect(Collectors.toList());
+
+        this.fileRepository.saveAll(files);
+
+        return files;
     }
 
     @Transactional

--- a/src/main/java/com/cojar/whats_hot_backend/domain/base_module/file/service/FileService.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/base_module/file/service/FileService.java
@@ -177,4 +177,8 @@ public class FileService {
     public void saveAll(List<_File> files) {
         if (files != null) this.fileRepository.saveAll(files);
     }
+
+    public Long count() {
+        return this.fileRepository.count();
+    }
 }

--- a/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/category/entity/Category.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/category/entity/Category.java
@@ -37,4 +37,18 @@ public class Category extends BaseEntity {
 
         return String.join(" > ", names);
     }
+
+    @Override
+    public String toString() {
+
+        Category category = this;
+        String[] names = new String[category.getDepth()];
+
+        while(category != null) {
+            names[category.getDepth() - 1] = category.getName();
+            category = category.getParent();
+        }
+
+        return String.join(" > ", names);
+    }
 }

--- a/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/menu_item/service/MenuItemService.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/menu_item/service/MenuItemService.java
@@ -65,4 +65,8 @@ public class MenuItemService {
     public List<MenuItem> getAllBySpot(Spot spot) {
         return this.menuItemRepository.findAllBySpot(spot);
     }
+
+    public Long count() {
+        return this.menuItemRepository.count();
+    }
 }

--- a/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/menu_item/service/MenuItemService.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/menu_item/service/MenuItemService.java
@@ -32,6 +32,7 @@ public class MenuItemService {
         return menuItem;
     }
 
+    @Transactional
     public List<MenuItem> createAll(List<MenuItemDto> items, Spot spot) {
 
         List<MenuItem> menuItems = items.stream()
@@ -42,6 +43,9 @@ public class MenuItemService {
                         .build()
                 )
                 .collect(Collectors.toList());
+
+        this.menuItemRepository.saveAll(menuItems);
+
         return menuItems;
     }
 

--- a/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot/controller/SpotController.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot/controller/SpotController.java
@@ -55,11 +55,8 @@ public class SpotController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity createSpot(@Valid @RequestPart(value = "request") SpotRequest.CreateSpot request, Errors errors,
                                      @RequestPart(value = "images", required = false) List<MultipartFile> images) {
-        log.info("=== controller start ===");
 
         Spot spot = this.spotService.create(request, images, errors);
-        Spot createdSpot = this.spotService.getSpotById(spot.getId());
-        log.info("Created Spot: {}", createdSpot);
 
         ResData resData = ResData.of(
                 ResCode.S_02_01,

--- a/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot/controller/SpotController.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot/controller/SpotController.java
@@ -55,45 +55,13 @@ public class SpotController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity createSpot(@Valid @RequestPart(value = "request") SpotRequest.CreateSpot request, Errors errors,
                                      @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+        log.info("=== controller start ===");
 
-        ResData resData = this.spotService.createValidate(request, errors);
-        if (resData != null) return ResponseEntity.badRequest().body(resData);
+        Spot spot = this.spotService.create(request, images, errors);
+        Spot createdSpot = this.spotService.getSpotById(spot.getId());
+        log.info("Created Spot: {}", createdSpot);
 
-        Spot spot = this.spotService.create(request);
-
-        // hashtags 생성
-        List<SpotHashtag> spotHashtags = null;
-        if (request.getHashtags() != null) {
-            spotHashtags = this.spotHashtagService.createAll(request.getHashtags(), spot);
-            spot = this.spotService.updateHashtags(spot, spotHashtags);
-        }
-
-        // menu item 생성
-        List<MenuItem> menuItems = null;
-        if (request.getMenuItems() != null) {
-            menuItems = this.menuItemService.createAll(request.getMenuItems(), spot);
-            spot = this.spotService.updateMenuItems(spot, menuItems);
-        }
-
-        // images 생성
-        List<_File> files = null;
-        List<SpotImage> spotImages = null;
-        if (images != null) {
-            resData = this.fileService.validateAll(images);
-            if (resData != null) return ResponseEntity.badRequest().body(resData);
-            files = this.fileService.createAll(images, FileDomain.SPOT);
-            spotImages = this.spotImageService.createAll(files, spot);
-            spot = this.spotService.updateImages(spot, spotImages);
-        }
-
-        // 중간에 Fail, Exception 발생 시 실제 DB에 저장되지 않도록 나중에 저장
-        this.spotHashtagService.saveAll(spotHashtags);
-        this.menuItemService.saveAll(menuItems);
-        this.fileService.saveAll(files);
-        this.spotImageService.saveAll(spotImages);
-        this.spotService.save(spot);
-
-        resData = ResData.of(
+        ResData resData = ResData.of(
                 ResCode.S_02_01,
                 SpotDto.of(spot),
                 linkTo(this.getClass()).slash(spot.getId())

--- a/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot/entity/Spot.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot/entity/Spot.java
@@ -10,7 +10,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -37,19 +36,15 @@ public class Spot extends BaseEntity {
     @Builder.Default
     private Double averageScore = 0.0;
 
-    @Builder.Default
     @OneToMany(mappedBy = "spot", cascade = CascadeType.REMOVE)
-    private List<SpotHashtag> hashtags = new ArrayList<>();
+    private List<SpotHashtag> hashtags;
 
-    @Builder.Default
     @OneToMany(mappedBy = "spot", cascade = CascadeType.REMOVE)
-    private List<MenuItem> menuItems = new ArrayList<>();
+    private List<MenuItem> menuItems;
 
-    @Builder.Default
     @OneToMany(mappedBy = "spot", cascade = CascadeType.REMOVE)
-    private List<SpotImage> images = new ArrayList<>();
+    private List<SpotImage> images;
 
-    @Builder.Default
     @OneToMany(mappedBy = "spot", cascade = CascadeType.REMOVE)
-    private List<Review> reviews = new ArrayList<>();
+    private List<Review> reviews;
 }

--- a/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot/service/SpotService.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot/service/SpotService.java
@@ -24,7 +24,6 @@ import com.cojar.whats_hot_backend.global.response.ResCode;
 import com.cojar.whats_hot_backend.global.response.ResData;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -37,7 +36,6 @@ import java.util.List;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
-@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot/service/SpotService.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot/service/SpotService.java
@@ -1,32 +1,43 @@
 package com.cojar.whats_hot_backend.domain.spot_module.spot.service;
 
+import com.cojar.whats_hot_backend.domain.base_module.file.entity.FileDomain;
+import com.cojar.whats_hot_backend.domain.base_module.file.entity._File;
+import com.cojar.whats_hot_backend.domain.base_module.file.service.FileService;
 import com.cojar.whats_hot_backend.domain.review_module.review.entity.Review;
 import com.cojar.whats_hot_backend.domain.spot_module.category.entity.Category;
 import com.cojar.whats_hot_backend.domain.spot_module.category.repository.CategoryRepository;
+import com.cojar.whats_hot_backend.domain.spot_module.category.service.CategoryService;
 import com.cojar.whats_hot_backend.domain.spot_module.menu_item.entity.MenuItem;
+import com.cojar.whats_hot_backend.domain.spot_module.menu_item.service.MenuItemService;
 import com.cojar.whats_hot_backend.domain.spot_module.spot.controller.SpotController;
 import com.cojar.whats_hot_backend.domain.spot_module.spot.dto.SpotListDto;
 import com.cojar.whats_hot_backend.domain.spot_module.spot.entity.Spot;
 import com.cojar.whats_hot_backend.domain.spot_module.spot.repository.SpotRepository;
 import com.cojar.whats_hot_backend.domain.spot_module.spot.request.SpotRequest;
 import com.cojar.whats_hot_backend.domain.spot_module.spot_hashtag.entity.SpotHashtag;
+import com.cojar.whats_hot_backend.domain.spot_module.spot_hashtag.service.SpotHashtagService;
 import com.cojar.whats_hot_backend.domain.spot_module.spot_image.entity.SpotImage;
+import com.cojar.whats_hot_backend.domain.spot_module.spot_image.service.SpotImageService;
 import com.cojar.whats_hot_backend.global.errors.exception.ApiResponseException;
 import com.cojar.whats_hot_backend.global.response.DataModel;
 import com.cojar.whats_hot_backend.global.response.ResCode;
 import com.cojar.whats_hot_backend.global.response.ResData;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.Errors;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
@@ -35,7 +46,55 @@ public class SpotService {
     private final SpotRepository spotRepository;
     private final CategoryRepository categoryRepository;
 
-    public ResData createValidate(SpotRequest.CreateSpot request, Errors errors) {
+    private final FileService fileService;
+    private final CategoryService categoryService;
+    private final SpotHashtagService spotHashtagService;
+    private final MenuItemService menuItemService;
+    private final SpotImageService spotImageService;
+
+    private final EntityManager entityManager;
+
+    @Transactional
+    public Spot create(SpotRequest.CreateSpot request, List<MultipartFile> images, Errors errors) {
+
+        // request 에러 검증
+        this.createValidate(request, errors);
+
+        // images 에러 검증
+        this.fileService.validateAll(images);
+
+        // 검증 단계에서 에러 걸러짐
+        Category category = this.categoryService.getCategoryById(request.getCategoryId());
+
+        Spot spot = Spot.builder()
+                .category(category)
+                .name(request.getName())
+                .address(request.getAddress())
+                .contact(request.getContact())
+                .build();
+
+        this.spotRepository.save(spot);
+
+        // hashtags 생성
+        this.spotHashtagService.createAll(request.getHashtags(), spot);
+
+        // menu item 생성
+        this.menuItemService.createAll(request.getMenuItems(), spot);
+
+        // images 생성
+        List<_File> files = this.fileService.createAll(images, FileDomain.SPOT);
+        this.spotImageService.createAll(files, spot);
+
+        entityManager.refresh(spot);
+
+        return spot;
+    }
+
+    public long count() {
+        return this.spotRepository.count();
+    }
+
+    private void createValidate(SpotRequest.CreateSpot request, Errors errors) {
 
         if (errors.hasErrors()) {
             throw new ApiResponseException(
@@ -84,8 +143,6 @@ public class SpotService {
                     )
             );
         }
-
-        return null;
     }
 
     public Spot create(SpotRequest.CreateSpot request) {

--- a/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot_hashtag/service/SpotHashtagService.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot_hashtag/service/SpotHashtagService.java
@@ -24,6 +24,8 @@ public class SpotHashtagService {
     @Transactional
     public List<SpotHashtag> createAll(List<String> hashtags, Spot spot) {
 
+        if (hashtags == null) return null;
+
         List<SpotHashtag> spotHashtags = hashtags.stream()
                 .map(hashtag -> {
                             Hashtag _hashtag = this.hashtagRepository.findByName(hashtag).orElse(null);
@@ -38,6 +40,8 @@ public class SpotHashtagService {
                         }
                 )
                 .collect(Collectors.toList());
+
+        this.spotHashtagRepository.saveAll(spotHashtags);
 
         return spotHashtags;
     }

--- a/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot_hashtag/service/SpotHashtagService.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot_hashtag/service/SpotHashtagService.java
@@ -62,4 +62,8 @@ public class SpotHashtagService {
     public List<SpotHashtag> getAllBySpot(Spot spot) {
         return this.spotHashtagRepository.findAllBySpot(spot);
     }
+
+    public Long count() {
+        return this.spotHashtagRepository.count();
+    }
 }

--- a/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot_image/service/SpotImageService.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot_image/service/SpotImageService.java
@@ -17,6 +17,7 @@ public class SpotImageService {
 
     private final SpotImageRepository spotImageRepository;
 
+    @Transactional
     public List<SpotImage> createAll(List<_File> files, Spot spot) {
 
         List<SpotImage> spotImages = files.stream()
@@ -27,6 +28,9 @@ public class SpotImageService {
                                 .build()
                 )
                 .collect(Collectors.toList());
+
+        this.spotImageRepository.saveAll(spotImages);
+
         return spotImages;
     }
 

--- a/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot_image/service/SpotImageService.java
+++ b/src/main/java/com/cojar/whats_hot_backend/domain/spot_module/spot_image/service/SpotImageService.java
@@ -50,4 +50,8 @@ public class SpotImageService {
     public List<SpotImage> getAllBySpot(Spot spot) {
         return this.spotImageRepository.findAllBySpot(spot);
     }
+
+    public Long count() {
+        return this.spotImageRepository.count();
+    }
 }

--- a/src/test/java/com/cojar/whats_hot_backend/domain/spot_module/spot/controller/SpotControllerTest.java
+++ b/src/test/java/com/cojar/whats_hot_backend/domain/spot_module/spot/controller/SpotControllerTest.java
@@ -118,13 +118,6 @@ class SpotControllerTest extends BaseControllerTest {
                 )
                 .andDo(print());
 
-//        resultActions = this.mockMvc
-//                .perform(get("/api/spots/%s".formatted(this.spotService.count()))
-//                        .contentType(MediaType.ALL)
-//                        .accept(MediaTypes.HAL_JSON)
-//                )
-//                .andDo(print());
-
         // then
         resultActions
                 .andExpect(status().isCreated())

--- a/src/test/java/com/cojar/whats_hot_backend/domain/spot_module/spot/controller/SpotControllerTest.java
+++ b/src/test/java/com/cojar/whats_hot_backend/domain/spot_module/spot/controller/SpotControllerTest.java
@@ -1,5 +1,6 @@
 package com.cojar.whats_hot_backend.domain.spot_module.spot.controller;
 
+import com.cojar.whats_hot_backend.domain.base_module.file.service.FileService;
 import com.cojar.whats_hot_backend.domain.spot_module.category.entity.Category;
 import com.cojar.whats_hot_backend.domain.spot_module.category.service.CategoryService;
 import com.cojar.whats_hot_backend.domain.spot_module.menu_item.dto.MenuItemDto;
@@ -54,6 +55,10 @@ class SpotControllerTest extends BaseControllerTest {
     @Autowired
     private SpotImageService spotImageService;
 
+    @Autowired
+    private FileService fileService;
+
+    @Transactional
     @Test
     @DisplayName("post:/api/spots - created, S-02-01")
     public void createSpot_Created() throws Exception {
@@ -164,6 +169,12 @@ class SpotControllerTest extends BaseControllerTest {
         String password = "1234";
         String accessToken = "Bearer " + this.memberService.getAccessToken(loginReq.of(username, password));
 
+        Long expectId = this.spotService.count() + 1;
+        Long expectHashTags = this.spotHashtagService.count();
+        Long expectMenuItems = this.menuItemService.count();
+        Long expectSpotImages = this.spotImageService.count();
+        Long expectFiles = this.fileService.count();
+
         SpotRequest.CreateSpot request = SpotRequest.CreateSpot.builder()
                 .categoryId(categoryId)
                 .name(name)
@@ -222,6 +233,12 @@ class SpotControllerTest extends BaseControllerTest {
 
         if (categoryId == null) resultActions.andExpect(jsonPath("data[0].rejectedValue").doesNotExist());
         else resultActions.andExpect(jsonPath("data[0].rejectedValue").value(""));
+
+        assertThat(this.spotService.getSpotById(expectId)).isNull();
+        assertThat(this.spotHashtagService.count()).isEqualTo(expectHashTags);
+        assertThat(this.menuItemService.count()).isEqualTo(expectMenuItems);
+        assertThat(this.spotImageService.count()).isEqualTo(expectSpotImages);
+        assertThat(this.fileService.count()).isEqualTo(expectFiles);
     }
 
     private static Stream<Arguments> argsFor_createSpot_BadRequest_NotBlank() {
@@ -244,6 +261,12 @@ class SpotControllerTest extends BaseControllerTest {
         String username = "admin";
         String password = "1234";
         String accessToken = "Bearer " + this.memberService.getAccessToken(loginReq.of(username, password));
+
+        Long expectId = this.spotService.count() + 1;
+        Long expectHashTags = this.spotHashtagService.count();
+        Long expectMenuItems = this.menuItemService.count();
+        Long expectSpotImages = this.spotImageService.count();
+        Long expectFiles = this.fileService.count();
 
         Long categoryId = 1000000000L;
         String name = "쿠우쿠우 대전둔산점";
@@ -307,6 +330,12 @@ class SpotControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("data[0].defaultMessage").exists())
                 .andExpect(jsonPath("data[0].rejectedValue").value(categoryId))
         ;
+
+        assertThat(this.spotService.getSpotById(expectId)).isNull();
+        assertThat(this.spotHashtagService.count()).isEqualTo(expectHashTags);
+        assertThat(this.menuItemService.count()).isEqualTo(expectMenuItems);
+        assertThat(this.spotImageService.count()).isEqualTo(expectSpotImages);
+        assertThat(this.fileService.count()).isEqualTo(expectFiles);
     }
 
     @ParameterizedTest
@@ -318,6 +347,12 @@ class SpotControllerTest extends BaseControllerTest {
         String username = "admin";
         String password = "1234";
         String accessToken = "Bearer " + this.memberService.getAccessToken(loginReq.of(username, password));
+
+        Long expectId = this.spotService.count() + 1;
+        Long expectHashTags = this.spotHashtagService.count();
+        Long expectMenuItems = this.menuItemService.count();
+        Long expectSpotImages = this.spotImageService.count();
+        Long expectFiles = this.fileService.count();
 
         String name = "쿠우쿠우 대전둔산점";
         String address = "대전 서구 대덕대로233번길 17 해운빌딩 4층";
@@ -380,6 +415,12 @@ class SpotControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("data[0].defaultMessage").exists())
                 .andExpect(jsonPath("data[0].rejectedValue").value(categoryId))
         ;
+
+        assertThat(this.spotService.getSpotById(expectId)).isNull();
+        assertThat(this.spotHashtagService.count()).isEqualTo(expectHashTags);
+        assertThat(this.menuItemService.count()).isEqualTo(expectMenuItems);
+        assertThat(this.spotImageService.count()).isEqualTo(expectSpotImages);
+        assertThat(this.fileService.count()).isEqualTo(expectFiles);
     }
 
     private static Stream<Arguments> argsFor_createSpot_BadRequest_InvalidCategoryId() {
@@ -397,6 +438,12 @@ class SpotControllerTest extends BaseControllerTest {
         String username = "admin";
         String password = "1234";
         String accessToken = "Bearer " + this.memberService.getAccessToken(loginReq.of(username, password));
+
+        Long expectId = this.spotService.count() + 1;
+        Long expectHashTags = this.spotHashtagService.count();
+        Long expectMenuItems = this.menuItemService.count();
+        Long expectSpotImages = this.spotImageService.count();
+        Long expectFiles = this.fileService.count();
 
         Long categoryId = 3L;
         String name = "장소1";
@@ -460,6 +507,12 @@ class SpotControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("data[0].rejectedValue[0]").value(name))
                 .andExpect(jsonPath("data[0].rejectedValue[1]").value(address))
         ;
+
+        assertThat(this.spotService.getSpotById(expectId)).isNull();
+        assertThat(this.spotHashtagService.count()).isEqualTo(expectHashTags);
+        assertThat(this.menuItemService.count()).isEqualTo(expectMenuItems);
+        assertThat(this.spotImageService.count()).isEqualTo(expectSpotImages);
+        assertThat(this.fileService.count()).isEqualTo(expectFiles);
     }
 
     @Test
@@ -470,6 +523,12 @@ class SpotControllerTest extends BaseControllerTest {
         String username = "admin";
         String password = "1234";
         String accessToken = "Bearer " + this.memberService.getAccessToken(loginReq.of(username, password));
+
+        Long expectId = this.spotService.count() + 1;
+        Long expectHashTags = this.spotHashtagService.count();
+        Long expectMenuItems = this.menuItemService.count();
+        Long expectSpotImages = this.spotImageService.count();
+        Long expectFiles = this.fileService.count();
 
         Long categoryId = 3L;
         String name = "쿠우쿠우 대전둔산점";
@@ -526,6 +585,12 @@ class SpotControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("data[0].defaultMessage").exists())
                 .andExpect(jsonPath("data[0].rejectedValue").value(MediaType.TEXT_MARKDOWN_VALUE))
         ;
+
+        assertThat(this.spotService.getSpotById(expectId)).isNull();
+        assertThat(this.spotHashtagService.count()).isEqualTo(expectHashTags);
+        assertThat(this.menuItemService.count()).isEqualTo(expectMenuItems);
+        assertThat(this.spotImageService.count()).isEqualTo(expectSpotImages);
+        assertThat(this.fileService.count()).isEqualTo(expectFiles);
     }
 
     @Test
@@ -536,6 +601,12 @@ class SpotControllerTest extends BaseControllerTest {
         String username = "admin";
         String password = "1234";
         String accessToken = "Bearer " + this.memberService.getAccessToken(loginReq.of(username, password));
+
+        Long expectId = this.spotService.count() + 1;
+        Long expectHashTags = this.spotHashtagService.count();
+        Long expectMenuItems = this.menuItemService.count();
+        Long expectSpotImages = this.spotImageService.count();
+        Long expectFiles = this.fileService.count();
 
         Long categoryId = 3L;
         String name = "쿠우쿠우 대전둔산점";
@@ -592,6 +663,12 @@ class SpotControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("data[0].defaultMessage").exists())
                 .andExpect(jsonPath("data[0].rejectedValue").value(MediaType.IMAGE_GIF_VALUE))
         ;
+
+        assertThat(this.spotService.getSpotById(expectId)).isNull();
+        assertThat(this.spotHashtagService.count()).isEqualTo(expectHashTags);
+        assertThat(this.menuItemService.count()).isEqualTo(expectMenuItems);
+        assertThat(this.spotImageService.count()).isEqualTo(expectSpotImages);
+        assertThat(this.fileService.count()).isEqualTo(expectFiles);
     }
 
     @Test
@@ -602,6 +679,12 @@ class SpotControllerTest extends BaseControllerTest {
         String username = "admin";
         String password = "1234";
         String accessToken = "Bearer " + this.memberService.getAccessToken(loginReq.of(username, password));
+
+        Long expectId = this.spotService.count() + 1;
+        Long expectHashTags = this.spotHashtagService.count();
+        Long expectMenuItems = this.menuItemService.count();
+        Long expectSpotImages = this.spotImageService.count();
+        Long expectFiles = this.fileService.count();
 
         Long categoryId = 3L;
         String name = "쿠우쿠우 대전둔산점";
@@ -674,6 +757,12 @@ class SpotControllerTest extends BaseControllerTest {
                 .andExpect(jsonPath("data[1].defaultMessage").exists())
                 .andExpect(jsonPath("data[1].rejectedValue").value(MediaType.IMAGE_GIF_VALUE))
         ;
+
+        assertThat(this.spotService.getSpotById(expectId)).isNull();
+        assertThat(this.spotHashtagService.count()).isEqualTo(expectHashTags);
+        assertThat(this.menuItemService.count()).isEqualTo(expectMenuItems);
+        assertThat(this.spotImageService.count()).isEqualTo(expectSpotImages);
+        assertThat(this.fileService.count()).isEqualTo(expectFiles);
     }
 
     @Test

--- a/src/test/java/com/cojar/whats_hot_backend/domain/spot_module/spot/controller/SpotControllerTest.java
+++ b/src/test/java/com/cojar/whats_hot_backend/domain/spot_module/spot/controller/SpotControllerTest.java
@@ -118,6 +118,13 @@ class SpotControllerTest extends BaseControllerTest {
                 )
                 .andDo(print());
 
+//        resultActions = this.mockMvc
+//                .perform(get("/api/spots/%s".formatted(this.spotService.count()))
+//                        .contentType(MediaType.ALL)
+//                        .accept(MediaTypes.HAL_JSON)
+//                )
+//                .andDo(print());
+
         // then
         resultActions
                 .andExpect(status().isCreated())


### PR DESCRIPTION
## 작업 브랜치
- feature/post-api-spots

## 작업 진행 및 변경 사항
- 생성 로직 트랜잭션 중 Fail 발생 시 엔티티 전부 생성되지 않도록 수정
- 관련 TC에서 엔티티 미생성 확인하도록 수정
- 자식 엔티티 저장 후 Spot 객체에 자동으로 저장되지 않는 문제 해결
```java
entityManager.refresh(spot);
```

## 이후 할 작업
- 기타 생성/수정 부분에 수정 사항 반영 작업

## P.S.
##### 확인 후 리뷰 부탁합니다.
